### PR TITLE
Fix lsp tests breaking from new LuaJIT version

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -292,8 +292,9 @@ local constants = {
 }
 
 for k, v in pairs(constants) do
-  vim.tbl_add_reverse_lookup(v)
-  protocol[k] = v
+  local tbl = vim.deepcopy(v)
+  vim.tbl_add_reverse_lookup(tbl)
+  protocol[k] = tbl
 end
 
 --[=[
@@ -623,7 +624,14 @@ function protocol.make_client_capabilities()
 
         codeActionLiteralSupport = {
           codeActionKind = {
-            valueSet = vim.tbl_values(protocol.CodeActionKind);
+            valueSet = (function()
+              local res = {}
+              for _, v in pairs(constants.CodeActionKind) do
+                table.insert(res, v)
+              end
+              table.sort(res)
+              return res
+            end)();
           };
         };
       };
@@ -643,7 +651,7 @@ function protocol.make_client_capabilities()
         completionItemKind = {
           valueSet = (function()
             local res = {}
-            for k in pairs(protocol.CompletionItemKind) do
+            for k in ipairs(protocol.CompletionItemKind) do
               if type(k) == 'number' then table.insert(res, k) end
             end
             return res
@@ -689,7 +697,7 @@ function protocol.make_client_capabilities()
         symbolKind = {
           valueSet = (function()
             local res = {}
-            for k in pairs(protocol.SymbolKind) do
+            for k in ipairs(protocol.SymbolKind) do
               if type(k) == 'number' then table.insert(res, k) end
             end
             return res
@@ -708,7 +716,7 @@ function protocol.make_client_capabilities()
         symbolKind = {
           valueSet = (function()
             local res = {}
-            for k in pairs(protocol.SymbolKind) do
+            for k in ipairs(protocol.SymbolKind) do
               if type(k) == 'number' then table.insert(res, k) end
             end
             return res

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -625,10 +625,7 @@ function protocol.make_client_capabilities()
         codeActionLiteralSupport = {
           codeActionKind = {
             valueSet = (function()
-              local res = {}
-              for _, v in pairs(constants.CodeActionKind) do
-                table.insert(res, v)
-              end
+              local res = vim.tbl_values(protocol.CodeActionKind)
               table.sort(res)
               return res
             end)();


### PR DESCRIPTION
Apparently the new version of LuaJIT changed the consistency with which it
sorted table dictionaries. IIRC lua sorts dictionary keys by memory address, so
it would appear that the reasons tests were previously passing was because of
a differentiation in the implementation of the lua runtime.

Ensure that array fields in the lsp protocol tables are consistently created,
by using ipair when generating arrays for completionItemKind and
symbolItemKind.

For CodeActionKind, the current implementation includes both the keys and the
values in the array. This is incorrect. Ensure that only the values are
included in the array and sort them for consistency.