### PR TITLE
Reenable `guifont[wide]` after VimR PR#830

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1137,7 +1137,6 @@ return {
       varname='p_guicursor',
       defaults={if_true={vi="n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20"}}
     },
-    --[[
     {
       full_name='guifont', abbreviation='gfn',
       short_desc=N_("GUI: Name(s) of font(s) to be used"),
@@ -1158,7 +1157,6 @@ return {
       varname='p_guifontwide',
       defaults={if_true={vi=""}}
     },
-    --]]
     {
       full_name='guioptions', abbreviation='go',
       short_desc=N_("GUI: Which components and options are used"),


### PR DESCRIPTION
This PR re-enables the `guifont` and `guifontwide` options in `options.lua` and is an aftermath of https://github.com/qvacua/vimr/pull/830 which implements basic handling of neovims `option_set` as well as handling for these specific options.